### PR TITLE
Adding PathSimAnalysis

### DIFF
--- a/mdakits/pathsimanalysis/metadata.yaml
+++ b/mdakits/pathsimanalysis/metadata.yaml
@@ -5,6 +5,7 @@ authors:
 
 maintainers:
   - ianmkenney
+  - orbeckst
 
 description:
     An MDAKit that calculates the geometric similarity of molecular dynamics trajectories using path metrics such as the Hausdorff or Fréchet distances.

--- a/mdakits/pathsimanalysis/metadata.yaml
+++ b/mdakits/pathsimanalysis/metadata.yaml
@@ -6,6 +6,7 @@ authors:
 maintainers:
   - ianmkenney
   - orbeckst
+  - IAlibay
 
 description:
     An MDAKit that calculates the geometric similarity of molecular dynamics trajectories using path metrics such as the Hausdorff or Fréchet distances.

--- a/mdakits/pathsimanalysis/metadata.yaml
+++ b/mdakits/pathsimanalysis/metadata.yaml
@@ -4,9 +4,10 @@ authors:
   - https://github.com/MDAnalysis/PathSimAnalysis/blob/main/AUTHORS.md
 
 maintainers:
-  - ianmkenney
-  - orbeckst
   - IAlibay
+  - ianmkenney
+  - lilyminium
+  - orbeckst
 
 description:
     An MDAKit that calculates the geometric similarity of molecular dynamics trajectories using path metrics such as the Hausdorff or Fréchet distances.

--- a/mdakits/pathsimanalysis/metadata.yaml
+++ b/mdakits/pathsimanalysis/metadata.yaml
@@ -1,0 +1,44 @@
+project_name: PathSimAnalysis
+
+authors:
+  - https://github.com/MDAnalysis/PathSimAnalysis/blob/main/AUTHORS.md
+
+maintainers:
+  - ianmkenney
+
+description:
+    An MDAKit that calculates the geometric similarity of molecular dynamics trajectories using path metrics such as the Hausdorff or Fréchet distances.
+
+keywords:
+  - similarity
+  - paths
+  - metrics
+
+license: GPL-2.0-or-later
+project_home: https://github.com/MDAnalysis/PathSimAnalysis/
+documentation_home: https://mdanalysis.org/PathSimAnalysis
+documentation_type: API
+
+install:
+  - pip install pathsimanalysis
+
+src_install:
+  - pip install git+https://github.com/MDAnalysis/PathSimAnalysis@main
+
+import_name: pathsimanalysis
+python_requires: ">=3.9"
+mdanalysis_requires: ">=2.0.0"
+
+run_tests:
+  - pytest --pyargs pathsimanalysis
+
+test_dependencies:
+  - mamba install pytest MDAnalysisTests
+
+project_org: MDAnalysis
+development_status: Production/Stable
+
+publications:
+  - https://doi.org/10.1371/journal.pcbi.1004568
+
+changelog: https://github.com/MDAnalysis/PathSimAnalysis/blob/main/CHANGELOG.md


### PR DESCRIPTION
Adding PathSimAnalysis to the MDAKits registry. This package computes the similarity between molecular dynamics trajectories using the Hausdorff or Fréchet distances.

@orbeckst would you like to be listed as a maintainer?