### PR TITLE
Swap out deprecated changed file action

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - id: files
         name: get changed filed
-        uses: jitterbit/get-changed-files@v1
+        uses: masesgroup/retrieve-changed-files@v3
         with:
           format: 'json'
       - id: get-changed-mdakits

--- a/mdakits/hole2-mdakit/metadata.yaml
+++ b/mdakits/hole2-mdakit/metadata.yaml
@@ -24,7 +24,7 @@ src_install:
   - git clone https://github.com/MDAnalysis/hole2-mdakit.git
   - mamba install hole2 -c conda-forge
   - cd hole2-mdakit && pip install . && cd ..
-python_requires: ">=3.8"
+python_requires: ">=3.9"
 mdanalysis_requires: ">=2.0.0"
 test_dependencies:
   - pip install pytest pytest-xdist


### PR DESCRIPTION
Fixes #108 

Bumping up hole2 python version whilst I'm at it, since the pip & conda released versions will also be 3.9+