### PR TITLE
add lipidorderkit to mdanalysis

### DIFF
--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -25,7 +25,7 @@ authors:
 ## Please note these _must_ be GitHub handles
 ## The maintainers will be tagged in issues if their MDAKit is failing.
 maintainers:
-  - Ricardo Ramirez
+  - ricard1997
 
 
 ## str: a free form description of the mdakit

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -31,7 +31,7 @@ project_home: https://github.com/ricard1997/lipidorderkit/
 documentation_home: https://lipidorderdocs.readthedocs.io/en/latest/
 
 
-documentation_type: UserGuide + API
+documentation_type: API
 
 
 install:

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -72,7 +72,7 @@ src_install:
   - pip install git+https://github.com/ricard1997/lipidorderkit@main
 
 ## str: the package name used to import the mdakit
-import_name: from lipidorder import lipid_order
+import_name: lipidorder
 
 ## str: a specification for the range of Python versions supported by this MDAKit
 python_requires: ">=3.10"

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -1,0 +1,122 @@
+# TEMPLATE MDAKit file
+# --------------------
+# 
+# Please replace ALL entries with appropriate content for YOUR MDAKit.
+# Below we use the placeholder GH_HOST_ACCOUNT for the GitHub account where
+# the source code repository is held, typically your username or the 
+# organization that you're part off.
+# MYPROJECT is the name of your project (the repository name and here
+# we assume that this is also the PyPi/conda package name) whereas 
+# MYPACKAGE is how you import it in python.
+#
+# See https://mdakits.mdanalysis.org/add.html for more information. 
+#
+#------------------------------------------------------------
+# Required entries
+#------------------------------------------------------------
+## str: name of the project (the respository name)
+project_name: lipidorderkit
+
+## List(str): a link to the authors file (preferred) or a list of authors 
+authors:
+  - https://github.com/ricard1997/lipidorderkit/blob/main/AUTHORS.md
+
+## List(str): a list of maintainers
+## Please note these _must_ be GitHub handles
+## The maintainers will be tagged in issues if their MDAKit is failing.
+maintainers:
+  - Ricardo Ramirez
+
+
+## str: a free form description of the mdakit
+description:
+    This MDAKit allow for the calculation of lipid order parameters for all atom molecualr dynamics simulations.
+
+## List(str): a list of keywords which describe the mdakit
+keywords:
+  - Lipids
+  - Lipids order parameters
+  - SCD
+  - Lipid metrics
+  - Lipid study
+
+## str: the license the mdakit falls under
+## See https://spdx.org/licenses/ for valid license specifiers
+license: GPL-2.0-or-later
+
+## str: the link to the project's code
+## Please note that this is not limited to GitHub! Can be Gitlab, etc..
+project_home: https://github.com/ricard1997/lipidorderkit/
+
+## str: the link to the project's documentation
+documentation_home: https://lipidorderdocs.readthedocs.io/en/latest/
+
+## str: the type of documentation available [UserGuide, API, README]
+documentation_type: UserGuide + API
+
+#------------------------------------------------------------
+# Optional entries
+#------------------------------------------------------------   
+## List(str): a list of commands to use when installing the latest
+## release of the code. Note: only one installation method can currently
+## be defined. We suggest using mamba where possible (e.g.
+##   mamba -c conda-forge install MYPROJECT
+## for a conda package installation).
+## Here we use a simple PyPi installation:
+install:
+  - pip install lipidoderkit
+
+## List(str): a list of commands to use when installing the mdakit from its
+## source code.
+src_install:
+  - pip install git+https://github.com/ricard1997/lipidorderkit@main
+
+## str: the package name used to import the mdakit
+import_name: from lipidorder import lipid_order
+
+## str: a specification for the range of Python versions supported by this MDAKit
+python_requires: ">=3.10"
+
+## str: a specification for the range of MDAnalysis versions supported by this MDAKit
+mdanalysis_requires: ">=2.0.0"
+
+## List(str): a list of commands to use when attempting to run the MDAKit's tests
+## If you package your tests inside your package then you can typically use the 
+##     pytest --pyargs MYPACKAGE
+## command as shown below. 
+## Otherwise you need to include commands to make the tests available. 
+## For example, if the tests are in the repository at the top level under `./tests`:
+## First use `git clone latest` to either clone the top commit for "development code" checks or check out
+## the latest tag for "latest release" checks. Then then run pytest:
+##    - git clone latest
+##    - pytest -v ./tests
+## Feel free to ask for advice on your pull request!
+run_tests:
+  - pytest --pyargs lipidorderkit
+
+## List(str): a list of commands to use to install the necessary dependencies required
+## to run the MDAKit's tests.
+## The default below _might_ be sufficient or you might not even need MDAnalysisTests:
+## make sure that it is appropriate for how you run tests.
+test_dependencies:
+  - mamba install pytest MDAnalysisTests
+
+## str: the organisation name the MDAKit falls under
+project_org: GH_HOST_ACCOUNT
+
+## str: the development status of the MDAKit
+## See https://pypi.org/classifiers/ for development status classifiers.
+development_status: Production/Stable
+
+## List(str) a list of publications to cite when using the MDAKit
+## Links to scientific publications or stable URLs (typically of the form
+## https://doi.org/<DOI> or to a preprint server)
+publications:
+  - https://doi.org/10.3389/fchem.2022.1088058
+
+
+## str: a link to the MDAKit's community (mailing list, github discussions, etc...)
+community_home: URL
+
+## str: a link to the MDAKit's changelog
+changelog: https://github.com/ricard1997/lipidorderkit/blob/main/CHANGELOG.md

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -1,38 +1,19 @@
-# TEMPLATE MDAKit file
-# --------------------
-# 
-# Please replace ALL entries with appropriate content for YOUR MDAKit.
-# Below we use the placeholder GH_HOST_ACCOUNT for the GitHub account where
-# the source code repository is held, typically your username or the 
-# organization that you're part off.
-# MYPROJECT is the name of your project (the repository name and here
-# we assume that this is also the PyPi/conda package name) whereas 
-# MYPACKAGE is how you import it in python.
-#
-# See https://mdakits.mdanalysis.org/add.html for more information. 
-#
-#------------------------------------------------------------
-# Required entries
-#------------------------------------------------------------
-## str: name of the project (the respository name)
 project_name: lipidorderkit
 
-## List(str): a link to the authors file (preferred) or a list of authors 
+
 authors:
   - https://github.com/ricard1997/lipidorderkit/blob/main/AUTHORS.md
 
-## List(str): a list of maintainers
-## Please note these _must_ be GitHub handles
-## The maintainers will be tagged in issues if their MDAKit is failing.
+
 maintainers:
   - ricard1997
 
 
-## str: a free form description of the mdakit
+
 description:
     This MDAKit allow for the calculation of lipid order parameters for all atom molecular dynamics simulations.
 
-## List(str): a list of keywords which describe the mdakit
+
 keywords:
   - Lipids
   - Lipids order parameters
@@ -40,84 +21,56 @@ keywords:
   - Lipid metrics
   - Lipid study
 
-## str: the license the mdakit falls under
-## See https://spdx.org/licenses/ for valid license specifiers
+
 license: GPL-2.0-or-later
 
-## str: the link to the project's code
-## Please note that this is not limited to GitHub! Can be Gitlab, etc..
+
 project_home: https://github.com/ricard1997/lipidorderkit/
 
-## str: the link to the project's documentation
+
 documentation_home: https://lipidorderdocs.readthedocs.io/en/latest/
 
-## str: the type of documentation available [UserGuide, API, README]
+
 documentation_type: UserGuide + API
 
-#------------------------------------------------------------
-# Optional entries
-#------------------------------------------------------------   
-## List(str): a list of commands to use when installing the latest
-## release of the code. Note: only one installation method can currently
-## be defined. We suggest using mamba where possible (e.g.
-##   mamba -c conda-forge install MYPROJECT
-## for a conda package installation).
-## Here we use a simple PyPi installation:
+
 install:
   - pip install git+https://github.com/ricard1997/lipidorderkit@main
 
-## List(str): a list of commands to use when installing the mdakit from its
-## source code.
+
 src_install:
   - git clone https://github.com/ricard1997/lipidorderkit.git
   - cd lipidorderkit && pip install . && cd ..
 
-## str: the package name used to import the mdakit
 import_name: lipidorder
 
-## str: a specification for the range of Python versions supported by this MDAKit
+
 python_requires: ">=3.10"
 
-## str: a specification for the range of MDAnalysis versions supported by this MDAKit
+
 mdanalysis_requires: ">=2.0.0"
 
-## List(str): a list of commands to use when attempting to run the MDAKit's tests
-## If you package your tests inside your package then you can typically use the 
-##     pytest --pyargs MYPACKAGE
-## command as shown below. 
-## Otherwise you need to include commands to make the tests available. 
-## For example, if the tests are in the repository at the top level under `./tests`:
-## First use `git clone latest` to either clone the top commit for "development code" checks or check out
-## the latest tag for "latest release" checks. Then then run pytest:
-##    - git clone latest
-##    - pytest -v ./tests
-## Feel free to ask for advice on your pull request!
+
 run_tests:
   - pytest --pyargs lipidorder
 
-## List(str): a list of commands to use to install the necessary dependencies required
-## to run the MDAKit's tests.
-## The default below _might_ be sufficient or you might not even need MDAnalysisTests:
-## make sure that it is appropriate for how you run tests.
+
 test_dependencies:
   - mamba install pytest MDAnalysisTests
 
-## str: the organisation name the MDAKit falls under
+
 project_org: ricard1997
 
-## str: the development status of the MDAKit
-## See https://pypi.org/classifiers/ for development status classifiers.
+
 development_status: Production/Stable
 
-## List(str) a list of publications to cite when using the MDAKit
-## Links to scientific publications or stable URLs (typically of the form
-## https://doi.org/<DOI> or to a preprint server)
+
 publications:
   - https://doi.org/10.3389/fchem.2022.1088058
 
 
-## str: a link to the MDAKit's community (mailing list, github discussions, etc...)
+
 community_home:
 
-## str: a link to the MDAKit's changelog
+
 changelog: https://github.com/ricard1997/lipidorderkit/blob/main/CHANGELOG.md

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -64,7 +64,7 @@ documentation_type: UserGuide + API
 ## for a conda package installation).
 ## Here we use a simple PyPi installation:
 install:
-  - pip install lipidoderkit
+  - pip install -e .
 
 ## List(str): a list of commands to use when installing the mdakit from its
 ## source code.

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -116,7 +116,7 @@ publications:
 
 
 ## str: a link to the MDAKit's community (mailing list, github discussions, etc...)
-community_home: URL
+community_home:
 
 ## str: a link to the MDAKit's changelog
 changelog: https://github.com/ricard1997/lipidorderkit/blob/main/CHANGELOG.md

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -92,7 +92,7 @@ mdanalysis_requires: ">=2.0.0"
 ##    - pytest -v ./tests
 ## Feel free to ask for advice on your pull request!
 run_tests:
-  - pytest --pyargs lipidorderkit
+  - pytest --pyargs lipidorder
 
 ## List(str): a list of commands to use to install the necessary dependencies required
 ## to run the MDAKit's tests.

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -30,7 +30,7 @@ maintainers:
 
 ## str: a free form description of the mdakit
 description:
-    This MDAKit allow for the calculation of lipid order parameters for all atom molecualr dynamics simulations.
+    This MDAKit allow for the calculation of lipid order parameters for all atom molecular dynamics simulations.
 
 ## List(str): a list of keywords which describe the mdakit
 keywords:

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -102,7 +102,7 @@ test_dependencies:
   - mamba install pytest MDAnalysisTests
 
 ## str: the organisation name the MDAKit falls under
-project_org: GH_HOST_ACCOUNT
+project_org: ricard1997
 
 ## str: the development status of the MDAKit
 ## See https://pypi.org/classifiers/ for development status classifiers.

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -64,7 +64,7 @@ documentation_type: UserGuide + API
 ## for a conda package installation).
 ## Here we use a simple PyPi installation:
 install:
-  - pip install -e .
+  - pip install git+https://github.com/ricard1997/lipidorderkit@main
 
 ## List(str): a list of commands to use when installing the mdakit from its
 ## source code.

--- a/mdakits/lipidorderkit/metadata.yaml
+++ b/mdakits/lipidorderkit/metadata.yaml
@@ -69,7 +69,8 @@ install:
 ## List(str): a list of commands to use when installing the mdakit from its
 ## source code.
 src_install:
-  - pip install git+https://github.com/ricard1997/lipidorderkit@main
+  - git clone https://github.com/ricard1997/lipidorderkit.git
+  - cd lipidorderkit && pip install . && cd ..
 
 ## str: the package name used to import the mdakit
 import_name: lipidorder


### PR DESCRIPTION
This code allows for the computation of lipid order parameters for all-atom MDAsimulation for researchers that study membrane simulations.