### PR TITLE
Add openmmdl as MDAKit

### DIFF
--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -54,12 +54,28 @@ install:
 src_install:
   - | 
     conda install -c conda-forge 
-    pip 
+    pip
+    pytest>=6.1.2
+    pytest-runner
+    numpy
+    plip
+    requests>=2.28.1
     mdtraj 
-    rdkit 
-    mdtraj 
-    plip 
-  - pip install https://github.com/wolberlab/OpenMMDL.git
+    rdkit>=2022.03.5
+    pdbfixer
+    openff-toolkit
+    openmmforcefields
+    cudatoolkit>=11.7.0
+    cuda-python>=11.7.1
+    mdanalysis>=2.3.0
+    pytest-shutil>=1.7.0
+    flask>=2.2.2
+    cairosvg
+    nglview
+    numba>=0.59.1
+    jupyter
+     
+  - pip install git+https://github.com/wolberlab/OpenMMDL
 
 ## str: the package name used to import the mdakit
 import_name: openmmdl

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -72,7 +72,7 @@ run_tests:
     if [ ! -d "OpenMMDL" ]; then
       git clone https://github.com/wolberlab/OpenMMDL.git
     fi
-    pytest OpenMMDL/
+  -  pytest OpenMMDL/
 
 ## str: the development status of the MDAKit
 ## See https://pypi.org/classifiers/ for development status classifiers.

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -52,9 +52,7 @@ install:
 ## List(str): a list of commands to use when installing the mdakit from its
 ## source code.
 src_install:
-  - conda install -c conda-forge \
-    pip \
-    'mdtraj' 
+  - conda install -c conda-forge pip mdtraj
   - git clone https://github.com/wolberlab/OpenMMDL.git
   - cd OpenMMDL
   - pip install . && cd ..

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -49,6 +49,11 @@ documentation_type: UserGuide + API + README
 install:
   - mamba install -c conda-forge openmmdl
 
+## List(str): a list of commands to use when installing the mdakit from its
+## source code.
+src_install:
+  - pip install git+https://github.com/wolberlab/OpenMMDL
+
 ## str: the package name used to import the mdakit
 import_name: openmmdl
 

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -68,11 +68,10 @@ mdanalysis_requires: ">=2.3.0"
 
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 run_tests:
-  - |
-    if [ ! -d "OpenMMDL" ]; then
-      git clone https://github.com/wolberlab/OpenMMDL.git
-    fi
-    pytest openmmdl/
+  - if [ ! -d "OpenMMDL" ]; then
+  -   git clone https://github.com/wolberlab/OpenMMDL.git
+  - fi
+  - pytest OpenMMDL/
 
 ## str: the development status of the MDAKit
 ## See https://pypi.org/classifiers/ for development status classifiers.

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -54,7 +54,7 @@ install:
 src_install:
   - git clone https://github.com/wolberlab/OpenMMDL.git
   - cd OpenMMDL
-  - conda install --file environment.yml 
+  - conda env update -f environment.yml 
   - pip install .
 
 ## str: the package name used to import the mdakit

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -52,6 +52,7 @@ install:
 ## List(str): a list of commands to use when installing the mdakit from its
 ## source code.
 src_install:
+  - mamba install -c conda-forge openmmdl
   - pip install git+https://github.com/wolberlab/OpenMMDL
 
 ## str: the package name used to import the mdakit

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -1,0 +1,75 @@
+# Required entries
+## str: name of the project (the respository name)
+project_name: OpenMMDL
+
+## List(str): a link to the authors file (preferred) or a list of authors 
+authors:
+  - https://github.com/wolberlab/OpenMMDL/blob/main/AUTHORS.md
+
+## List(str): a list of maintainers
+## Please note these _must_ be GitHub handles
+## The maintainers will be tagged in issues if their MDAKit is failing.
+maintainers:
+  - talagayev
+  - NDoering99
+  - xixichennn
+
+## str: a free form description of the mdakit
+description:
+    Interface to OpenMM for easy setup of molecular dynamic simulations of protein-ligand complexes and the analysis thereof
+
+## List(str): a list of keywords which describe the mdakit
+keywords:
+  - MD simulations
+  - Protein-ligand analysis
+  - flask-based webserver
+  - visualization
+  - openmm
+  - rdkit
+  - nglview
+
+## str: the license the mdakit falls under
+## See https://spdx.org/licenses/ for valid license specifiers
+license: MIT
+
+## str: the link to the project's code
+## Please note that this is not limited to GitHub! Can be Gitlab, etc..
+project_home: https://github.com/wolberlab/OpenMMDL
+
+## str: the link to the project's documentation
+documentation_home: http://openmmdl.readthedocs.io/
+
+## str: the type of documentation available [UserGuide, API, README]
+documentation_type: UserGuide + API + README
+
+#------------------------------------------------------------
+# Optional entries
+#------------------------------------------------------------   
+## List(str): a list of commands to use when installing the latest
+## release of the code. Note: only one installation method can currently
+## be defined. We suggest using mamba where possible (e.g.
+##   mamba -c conda-forge install MYPROJECT
+## for a conda package installation).
+## Here we use a simple PyPi installation:
+install:
+  - mamba install -c conda-forge openmmdl
+
+## str: the package name used to import the mdakit
+import_name: openmmdl
+
+## str: a specification for the range of Python versions supported by this MDAKit
+python_requires: ">=3.10"
+
+## str: a specification for the range of MDAnalysis versions supported by this MDAKit
+mdanalysis_requires: ">=2.3.0"
+
+## List(str): a list of commands to use when attempting to run the MDAKit's tests
+run_tests:
+  - pytest openmmdl/
+
+## str: the development status of the MDAKit
+## See https://pypi.org/classifiers/ for development status classifiers.
+development_status: "Development Status :: 4 - Beta"
+
+## str: a link to the MDAKit's changelog
+#changelog: https://github.com/wolberlab/OpenMMDL/blob/main/CHANGELOG.md

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -52,12 +52,11 @@ install:
 ## List(str): a list of commands to use when installing the mdakit from its
 ## source code.
 src_install:
+  - conda install -c conda-forge \
+    'setuptools>=61.0' \
   - git clone https://github.com/wolberlab/OpenMMDL.git
   - cd OpenMMDL
-  - conda env update -f environment.yml 
-  - conda activate openmmdl
   - pip install . && cd ..
-  - mv OpenMMDL/ OpenMMDL_env/
 
 ## str: the package name used to import the mdakit
 import_name: openmmdl

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -45,12 +45,6 @@ documentation_type: UserGuide + API + README
 #------------------------------------------------------------
 # Optional entries
 #------------------------------------------------------------   
-## List(str): a list of commands to use when installing the latest
-## release of the code. Note: only one installation method can currently
-## be defined. We suggest using mamba where possible (e.g.
-##   mamba -c conda-forge install MYPROJECT
-## for a conda package installation).
-## Here we use a simple PyPi installation:
 install:
   - mamba install -c conda-forge openmmdl
 
@@ -65,6 +59,7 @@ mdanalysis_requires: ">=2.3.0"
 
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 run_tests:
+  - git clone latest
   - pytest openmmdl/
 
 ## str: the development status of the MDAKit

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -55,6 +55,7 @@ src_install:
   - git clone https://github.com/wolberlab/OpenMMDL.git
   - cd OpenMMDL
   - conda env update -f environment.yml 
+  - conda activate openmmdl
   - pip install . && cd ..
   - mv OpenMMDL/ OpenMMDL_env/
 

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -68,7 +68,6 @@ mdanalysis_requires: ">=2.3.0"
 
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 run_tests:
-  - git clone latest
   - pytest openmmdl/
 
 ## str: the development status of the MDAKit

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -56,6 +56,7 @@ src_install:
   - cd OpenMMDL
   - conda env update -f environment.yml 
   - pip install . && cd ..
+  - mv OpenMMDL/ OpenMMDL_env/
 
 ## str: the package name used to import the mdakit
 import_name: openmmdl
@@ -68,7 +69,7 @@ mdanalysis_requires: ">=2.3.0"
 
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 run_tests:
-  - [ ! -d "OpenMMDL" ] && git clone https://github.com/wolberlab/OpenMMDL.git
+  - git clone latest
   - pytest OpenMMDL/
 
 ## str: the development status of the MDAKit

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -53,7 +53,7 @@ install:
 ## source code.
 src_install:
   - | 
-    conda install -c conda-forge 
+    mamba install -c conda-forge 
     pip
     setuptools>=61.0
     versioningit~=2.0

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -53,7 +53,7 @@ install:
 ## source code.
 src_install:
   - conda install -c conda-forge \
-    'setuptools>=61.0' \
+    'mdtraj' \
   - git clone https://github.com/wolberlab/OpenMMDL.git
   - cd OpenMMDL
   - pip install . && cd ..

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -52,10 +52,14 @@ install:
 ## List(str): a list of commands to use when installing the mdakit from its
 ## source code.
 src_install:
-  - conda install -c conda-forge pip mdtraj rdkit mdtraj plip
-  - git clone https://github.com/wolberlab/OpenMMDL.git
-  - cd OpenMMDL
-  - pip install . && cd ..
+  - | 
+    conda install -c conda-forge 
+    pip 
+    mdtraj 
+    rdkit 
+    mdtraj 
+    plip 
+  - pip install https://github.com/wolberlab/OpenMMDL.git
 
 ## str: the package name used to import the mdakit
 import_name: openmmdl

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -45,6 +45,7 @@ documentation_type: UserGuide + API + README
 #------------------------------------------------------------
 # Optional entries
 #------------------------------------------------------------   
+
 install:
   - mamba install -c conda-forge openmmdl
 

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -98,4 +98,4 @@ run_tests:
 development_status: "Development Status :: 4 - Beta"
 
 ## str: a link to the MDAKit's changelog
-#changelog: https://github.com/wolberlab/OpenMMDL/blob/main/CHANGELOG.md
+changelog: https://github.com/wolberlab/OpenMMDL/blob/main/CHANGELOG.md

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -53,7 +53,7 @@ install:
 ## source code.
 src_install:
   - conda install -c conda-forge \
-    'pip' \
+    pip \
     'mdtraj' 
   - git clone https://github.com/wolberlab/OpenMMDL.git
   - cd OpenMMDL

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -53,16 +53,12 @@ install:
 ## source code.
 src_install:
   - | 
-    mamba install -c conda-forge 
+    mamba install -c conda-forge
     pip
-    setuptools>=61.0
-    versioningit~=2.0
-    pytest>=6.1.2
-    pytest-runner
     numpy
     plip
     requests>=2.28.1
-    mdtraj 
+    mdtraj
     rdkit>=2022.03.5
     pdbfixer
     openff-toolkit
@@ -70,14 +66,15 @@ src_install:
     cudatoolkit>=11.7.0
     cuda-python>=11.7.1
     mdanalysis>=2.3.0
-    pytest-shutil>=1.7.0
     flask>=2.2.2
     cairosvg
     nglview
     numba>=0.59.1
     jupyter
-     
   - pip install git+https://github.com/wolberlab/OpenMMDL
+
+test_dependencies:
+  - mamba install pytest>=6.1.2 pytest-runner pytest-shutil>=1.7.0
 
 ## str: the package name used to import the mdakit
 import_name: openmmdl

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -68,11 +68,8 @@ mdanalysis_requires: ">=2.3.0"
 
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 run_tests:
-  - |
-    if [ ! -d "OpenMMDL" ]; then
-      git clone https://github.com/wolberlab/OpenMMDL.git
-    fi
-  -  pytest OpenMMDL/
+  - [ ! -d "OpenMMDL" ] && git clone https://github.com/wolberlab/OpenMMDL.git
+  - pytest OpenMMDL/
 
 ## str: the development status of the MDAKit
 ## See https://pypi.org/classifiers/ for development status classifiers.

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -68,7 +68,11 @@ mdanalysis_requires: ">=2.3.0"
 
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 run_tests:
-  - pytest openmmdl/
+  - |
+    if [ ! -d "OpenMMDL" ]; then
+      git clone https://github.com/wolberlab/OpenMMDL.git
+    fi
+    pytest openmmdl/
 
 ## str: the development status of the MDAKit
 ## See https://pypi.org/classifiers/ for development status classifiers.

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -68,10 +68,9 @@ mdanalysis_requires: ">=2.3.0"
 
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 run_tests:
-  - if [ ! -d "OpenMMDL" ]; then
-  -   git clone https://github.com/wolberlab/OpenMMDL.git
-  - fi
-  - pytest OpenMMDL/
+  - |
+    if [ ! -d "OpenMMDL" ]; then git clone https://github.com/wolberlab/OpenMMDL.git; fi
+    pytest OpenMMDL/
 
 ## str: the development status of the MDAKit
 ## See https://pypi.org/classifiers/ for development status classifiers.

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -53,7 +53,8 @@ install:
 ## source code.
 src_install:
   - conda install -c conda-forge \
-    'mdtraj' \
+    'pip' \
+    'mdtraj' 
   - git clone https://github.com/wolberlab/OpenMMDL.git
   - cd OpenMMDL
   - pip install . && cd ..

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -55,6 +55,8 @@ src_install:
   - | 
     conda install -c conda-forge 
     pip
+    setuptools>=61.0
+    versioningit~=2.0
     pytest>=6.1.2
     pytest-runner
     numpy

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -55,7 +55,7 @@ src_install:
   - git clone https://github.com/wolberlab/OpenMMDL.git
   - cd OpenMMDL
   - conda env update -f environment.yml 
-  - pip install .
+  - pip install . && cd ..
 
 ## str: the package name used to import the mdakit
 import_name: openmmdl

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -70,7 +70,7 @@ mdanalysis_requires: ">=2.3.0"
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 run_tests:
   - git clone latest
-  - pytest OpenMMDL/
+  - pytest openmmdl/
 
 ## str: the development status of the MDAKit
 ## See https://pypi.org/classifiers/ for development status classifiers.

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -69,7 +69,9 @@ mdanalysis_requires: ">=2.3.0"
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 run_tests:
   - |
-    if [ ! -d "OpenMMDL" ]; then git clone https://github.com/wolberlab/OpenMMDL.git; fi
+    if [ ! -d "OpenMMDL" ]; then
+      git clone https://github.com/wolberlab/OpenMMDL.git
+    fi
     pytest OpenMMDL/
 
 ## str: the development status of the MDAKit

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -52,8 +52,10 @@ install:
 ## List(str): a list of commands to use when installing the mdakit from its
 ## source code.
 src_install:
-  - mamba install -c conda-forge openmmdl
-  - pip install git+https://github.com/wolberlab/OpenMMDL
+  - git clone https://github.com/wolberlab/OpenMMDL.git
+  - cd OpenMMDL
+  - conda install --file environment.yml 
+  - pip install .
 
 ## str: the package name used to import the mdakit
 import_name: openmmdl

--- a/mdakits/openmmdl/metadata.yaml
+++ b/mdakits/openmmdl/metadata.yaml
@@ -52,7 +52,7 @@ install:
 ## List(str): a list of commands to use when installing the mdakit from its
 ## source code.
 src_install:
-  - conda install -c conda-forge pip mdtraj
+  - conda install -c conda-forge pip mdtraj rdkit mdtraj plip
   - git clone https://github.com/wolberlab/OpenMMDL.git
   - cd OpenMMDL
   - pip install . && cd ..


### PR DESCRIPTION
Addition of `OpenMMDL` to `MDAKits`:

Package for Interface to OpenMM for easy setup of molecular dynamic simulations of protein-ligand complexes and the analysis thereof, available at:

https://anaconda.org/conda-forge/openmmdl