### PR TITLE
Switch from mambaforge to miniforge

### DIFF
--- a/.github/workflows/gh-ci-cron.yaml
+++ b/.github/workflows/gh-ci-cron.yaml
@@ -79,13 +79,13 @@ jobs:
           
       - id: install-conda-env
         name: install-conda-env
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ env.PYVER }}
           add-pip-as-python-dependency: true
           architecture: x64
           use-mamba: true
-          miniforge-variant: Mambaforge
+          miniforge-version: latest
           channels: conda-forge, defaults
           channel-priority: flexible
           auto-update-conda: true

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -82,13 +82,13 @@ jobs:
           
       - id: install-conda-env
         name: install-conda-env
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ env.PYVER }}
           add-pip-as-python-dependency: true
           architecture: x64
           use-mamba: true
-          miniforge-variant: Mambaforge
+          miniforge-version: latest
           channels: conda-forge, defaults
           channel-priority: flexible
           auto-update-conda: true


### PR DESCRIPTION
mambaforge is going away and there have been brownouts that are affecting us, see #213 