### PR TITLE
updated pytim requirements

### DIFF
--- a/mdakits/pytim/metadata.yaml
+++ b/mdakits/pytim/metadata.yaml
@@ -54,10 +54,10 @@ src_install:
 import_name: pytim
 
 ## str: a specification for the range of Python versions supported by this MDAKit
-python_requires: ">=3.9"
+python_requires: ">=3.10"
 
 ## str: a specification for the range of MDAnalysis versions supported by this MDAKit
-mdanalysis_requires: ">=2.0.0"
+mdanalysis_requires: ">=2.8.0"
 
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 ## If you package your tests inside your package then you can typically use the 


### PR DESCRIPTION
The latest version (1.0.2) adds compatibility with numpy2 and MDA 2.8, but requires now python>3.1 and mdanalysis >=2.8.0