### PR TITLE
Add metada.yaml for menger_curvature MDAKit registration (v2)

### DIFF
--- a/mdakits/menger_curvature/metadata.yaml
+++ b/mdakits/menger_curvature/metadata.yaml
@@ -1,0 +1,80 @@
+project_name: Menger_Curvature
+
+authors:
+  - https://github.com/EtienneReboul/menger_curvature/blob/main/AUTHORS.md
+
+
+maintainers:
+  - IBPCREBOUL
+  - EtienneReboul
+
+description:
+    This project aims to provide a simple MDAkit for JIT accelerated Menger curvature calculation.
+    The idea is to associate a value of curvature to as many residues as possible in a polymer. 
+    If one has access to several conformations , the average value of the curvature (LC) and its standard deviation (LF) 
+    are valuable information to characterize the local dynamics of the backbone.
+
+
+keywords:
+  - IDP
+  - IDR
+  - flexibility
+  - Menger curvature
+  - protein
+
+license: GPL-2.0-or-later
+
+
+project_home: https://github.com/EtienneReboul/menger_curvature
+
+
+documentation_home: https://menger-curvature.readthedocs.io/
+
+
+documentation_type: UserGuide + API
+
+
+src_install:
+  - mamba install -c conda-forge numba mdanalysis
+  - pip install git+https://github.com/EtienneReboul/menger_curvature@main
+
+
+import_name: menger
+
+
+python_requires: ">=3.10"
+
+
+mdanalysis_requires: ">=2.0.0"
+
+
+run_tests:
+  - git clone latest 
+  - pytest ./menger/tests
+
+
+test_dependencies:
+  - mamba install pytest MDAnalysisTests
+
+
+project_org: EtienneReboul
+
+
+install:
+  - mamba install -c conda-forge numba mdanalysis
+  - pip install menger-curvature
+
+
+development_status: "Development Status :: 5 - Production/Stable"
+
+
+publications:
+  - https://pubs.acs.org/doi/abs/10.1021/acs.jcim.4c00742
+  - https://doi.org/10.1101/2025.02.22.639620
+  - https://doi.org/10.1101/2025.02.19.638976
+
+
+community_home: https://github.com/EtienneReboul/menger_curvature/discussions/
+
+
+changelog: https://github.com/EtienneReboul/menger_curvature/blob/main/CHANGELOG.md


### PR DESCRIPTION
Summary :
-  the file was extensively modfied in previous PR  : https://github.com/MDAnalysis/MDAKits/pull/265#issuecomment-2769966558
- the issue with previous fork comes from  commit history: it was messy due to manually runned CI github action in conjonction with multiple fork sync in the middle of the PR 
- It successfully fixed CI dependencies issue were  installing mdanalysis with mamba would install a new version of numpy that was not compatible with numba

Initial PR message : 
Add Menger_Curvature to MDAkit. This project aims to provide a simple MDAkit for JIT accelerated Menger curvature calculation.
The idea is to associate a value of curvature to as many residues as possible in a polymer. If one has access to several conformations , the average value of the curvature (LC) and its standard deviation (LF) are valuable information to characterize the local dynamics of the backbone.