### PR TITLE
update mdacli metadata

### DIFF
--- a/mdakits/mdacli/metadata.yaml
+++ b/mdakits/mdacli/metadata.yaml
@@ -20,11 +20,11 @@ install:
   - mamba install -c conda-forge mdacli
 src_install:
   - pip install git+https://github.com/MDAnalysis/mdacli@main
-python_requires: ">=3.7"
-mdanalysis_requires: ">=2.1.0"
+python_requires: ">=3.11"
+mdanalysis_requires: ">=2.10.0"
 run_tests:
   - git clone latest
-  - tox -e test
+  - tox -e tests
 test_dependencies:
   - pip install tox
 project_org: MDAnalysis


### PR DESCRIPTION
Fixes #302, #303

We have to wait for the conda release of v0.1.33. Should be triggered soon...

