### PR TITLE
Add status badge documentation for MDAKits

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,7 @@ resources on MDAKits and how to write and/or add your own, follow the links belo
    addingakit
    maintainingakit
    troubleshooting
+   badge
 
 
 .. toctree::


### PR DESCRIPTION
This PR introduces automated badge generation for MDAKits to indicate their testing status.
If both latest and develop tests pass, the badge shows MDAKit: pass (green).
If any test fails, it displays MDAKit: failing (red).