### PR TITLE
update links to the MDA cookiecutter docs

### DIFF
--- a/docs/source/maintaining_a_kit/logo.rst
+++ b/docs/source/maintaining_a_kit/logo.rst
@@ -20,8 +20,7 @@ on updating this.
 
 
 .. _`MDAKits cookiecutter documentation`:
-   https://cookiecutter-mdakit.readthedocs.io/en/latest/usage.html#documentation-configuration
-
+   https://www.mdanalysis.org/cookiecutter-mdakit/usage.html#documentation-configuration
 
 .. _`'empty gear' template`:
    https://github.com/MDAnalysis/branding/tree/main/templates/MDAKits

--- a/docs/source/making_a_kit/guided_example/use-cookiecutter.rst
+++ b/docs/source/making_a_kit/guided_example/use-cookiecutter.rst
@@ -1,6 +1,6 @@
-************************************
-Part 1: Using the MDAKit cookicutter
-************************************
+*************************************
+Part 1: Using the MDAKit cookiecutter
+*************************************
 
 *See our* `YouTube tutorial <https://www.youtube.com/watch?v=viCPUHkgSxg&t=38s>`_
 *for a video demonstration of this section.*
@@ -105,8 +105,11 @@ Progress: MDAKit requirements
 
 .. _`Cookiecutter tool`: https://cookiecutter.readthedocs.io/en/stable/
 
-.. _`MDAKit cookiecutter documentation`: https://cookiecutter-mdakit.readthedocs.io/en/latest/
+.. _`MDAKit cookiecutter documentation`:
+   https://www.mdanalysis.org/cookiecutter-mdakit
 
-.. _`cookiecutter options`: https://cookiecutter-mdakit.readthedocs.io/en/latest/options
+.. _`cookiecutter options`:
+   https://www.mdanalysis.org/cookiecutter-mdakit/getting_started.html#options.io/en/latest/options
 
-.. _`cookiecutter usage`: https://cookiecutter-mdakit.readthedocs.io/en/latest/usage
+.. _`cookiecutter usage`:
+   https://www.mdanalysis.org/cookiecutter-mdakit/getting_started.html#basic-usage

--- a/docs/source/makingakit.rst
+++ b/docs/source/makingakit.rst
@@ -11,7 +11,7 @@ Building a Kit using the cookiecutter
 -------------------------------------
 
 Without prior experience, some of the MDAKit Registry requirements
-can be daunting. The `MDAKit cookiecutter <https://cookiecutter-mdakit.readthedocs.io/>`_
+can be daunting. The `MDAKit cookiecutter`_
 can be used to aid rapid development of a FAIR-compliant MDAKit
 by generating placeholder code for documentation, testing and 
 installation. A guided example of creating an MDAKit, from cookiecutter
@@ -42,3 +42,5 @@ information below.
    making_a_kit/hosting
    making_a_kit/testing
    making_a_kit/documentation
+
+.. _`MDAKit cookiecutter`: https://www.mdanalysis.org/cookiecutter-mdakit   


### PR DESCRIPTION
- link to our own pages instead of RTD
- update links after doc restructure https://github.com/MDAnalysis/cookiecutter-mdakit/pull/145