### PR TITLE
Add guidance on how to solve problems to the issue template #337

### DIFF
--- a/utils/mdakit.py
+++ b/utils/mdakit.py
@@ -322,7 +322,12 @@ class MDAKit:
                     f"  - installing mdanalysis: {_bool_status(stat.install_mdanalysis)}\n"
                     f"  - installing the test dependencies: {_bool_status(stat.install_test_deps)}\n"
                     f"  - running tests: {_bool_status(stat.run_tests)}\n"
-                    f"Pinging maintainers: {maint}"
+                    f"Pinging maintainers: {maint}\n\n"
+                    f"---\n"
+                    f"**How to resolve this:**\n\n"
+                    f"- **Check the `metadata.yaml`**: Ensure your kit's `metadata.yaml` is up-to-date.\n"
+                    f"- **Check why the pipeline is failing**: Look at the CI logs to find the exact point of failure. See the [documentation on finding the CI error](https://mdakits.mdanalysis.org/maintaining_a_kit/keep-healthy.html#why-did-ci-fail).\n"
+                    f"- **Pipeline details**: For an in-depth explanation of how the MDAKits Registry CI works, please see [the documentation here](https://mdakits.mdanalysis.org/maintaining_a_kit/keep-healthy.html#mdakitsci).\n"
             )
 
             repo.create_issue(title=issue_title, body=issue_body)


### PR DESCRIPTION
Fixes #337

This PR adds troubleshooting guidance to the issue template that is automatically generated upon MDAKits CI pipeline failure.

Changes included:
- Added a recommendation to check that the `metadata.yaml` is up-to-date.
- Included an explanation and link to the documentation on how to find why the pipeline is failing from the CI logs.
- Added a link to the in-depth documentation explaining how the MDAKits Registry CI pipeline works.
