### PR TITLE
Update membrane curvature metadata

### DIFF
--- a/mdakits/membrane-curvature/metadata.yaml
+++ b/mdakits/membrane-curvature/metadata.yaml
@@ -98,7 +98,7 @@ run_tests:
 ## The default below _might_ be sufficient or you might not even need MDAnalysisTests:
 ## make sure that it is appropriate for how you run tests.
 test_dependencies:
-  - pip install pytest MDAnalysisTests
+  - mamba install pytest MDAnalysisTests
 
 ## str: the organisation name the MDAKit falls under
 project_org: MDAnalysis

--- a/mdakits/membrane-curvature/metadata.yaml
+++ b/mdakits/membrane-curvature/metadata.yaml
@@ -74,10 +74,10 @@ src_install:
 import_name: membrane_curvature
 
 ## str: a specification for the range of Python versions supported by this MDAKit
-python_requires: ">=3.9"
+python_requires: ">=3.11"
 
 ## str: a specification for the range of MDAnalysis versions supported by this MDAKit
-mdanalysis_requires: ">=2.0.0"
+mdanalysis_requires: ">=2.4.0"
 
 ## List(str): a list of commands to use when attempting to run the MDAKit's tests
 ## If you package your tests inside your package then you can typically use the 

--- a/mdakits/membrane-curvature/metadata.yaml
+++ b/mdakits/membrane-curvature/metadata.yaml
@@ -98,7 +98,7 @@ run_tests:
 ## The default below _might_ be sufficient or you might not even need MDAnalysisTests:
 ## make sure that it is appropriate for how you run tests.
 test_dependencies:
-  - mamba install pytest MDAnalysisTests
+  - pip install pytest MDAnalysisTests
 
 ## str: the organisation name the MDAKit falls under
 project_org: MDAnalysis


### PR DESCRIPTION
Fixes #366 

As per most recent project metadata from [membrane-curvature/pyproject.toml](https://github.com/MDAnalysis/membrane-curvature/blob/main/pyproject.toml).  Updated membrane-curvature MDAKit metadata with:

 - Bumped python_requires: `">=3.9"` -> `>=3.11`
 - Bumped mdanalysis_requires:  `">=2.0.0"` -> `">=2.4.0"`