### PR TITLE
update logo license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -454,7 +454,7 @@ SOFTWARE.
 
 MDAnalysis and MDAKit logo
 
-MDAnalysis™ is a registered trademark of NumFOCUS, Inc. The MDAnalysis 'Atom'
+MDAnalysis® is a registered trademark of NumFOCUS, Inc. The MDAnalysis 'Atom'
 logo and the 'MDAKits Registry' logo are copyrighted by NumFOCUS, Inc. These
 two logos may not be used outside the MDAnalysis organization unless explicit
 written permission has been granted by NumFOCUS, Inc.

--- a/LICENSE
+++ b/LICENSE
@@ -452,23 +452,12 @@ SOFTWARE.
 
 =======================================================================
 
-MDAnalysis logo
+MDAnalysis and MDAKit logo
 
-The MDAnalysis 'Atom' logo was created by Christian Beckstein and is
-
-Copyright (c) 2011 Christian Beckstein
-
-MDAnalysis Logo 'Atom' by Christian Beckstein is licensed under a
-Creative Commons Attribution-NoDerivs 3.0 Unported License.
-To view a copy of this license, visit
-http://creativecommons.org/licenses/by-nd/3.0/ or send a letter to Creative
-Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
-
-The logo, and derivatives as detailed in the MDAnalysis/mdanalysis github
-repository, can be found in some of the individual sessions/lectures under the
-'imgs' directories. These are named "mdalogo.png" and "MDA-Background.png".
-Derivatives of the logo are also embedded in "Day3-Session1-Lecture/MDAParallelization.pdf"
-and "Day3-Closing-Lecture/MDAnalysis_Workshop_final_no_logo.pdf".
-
+MDAnalysis™ is a registered trademark of NumFOCUS, Inc. The MDAnalysis 'Atom'
+logo and the 'MDAKits Registry' logo are copyrighted by NumFOCUS, Inc. These
+two logos may not be used outside the MDAnalysis organization unless explicit
+written permission has been granted by NumFOCUS, Inc.
 
 =======================================================================
+


### PR DESCRIPTION
- fix #62
- noted MDAnalysis trademark
- noted copyright on included logos belongs to NumFOCUS